### PR TITLE
use drop-down menu with and add logo link

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@yaireo/tagify": "^3.2.6",
     "axios": "^0.19.1",
+    "semantic-ui-vue": "^0.11.0",
     "v-viewer": "^1.5.1",
     "vue": "^2.6.10",
     "vue-router": "^3.3.4"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,29 @@
 <template>
-  <div id="app">
-    <div class="ui secondary pointing menu">
-      <router-link class="item" to="/questions">Questions</router-link>
-      <router-link class="item" to="/insights">Insights</router-link>
-      <router-link class="item" to="/settings">Settings</router-link>
+  <div>
+    <div class="menu-container">
+      <sui-menu class="large" attached="top">
+        <sui-dropdown item icon="bars" simple>
+          <sui-dropdown-menu>
+            <sui-dropdown-header>Games</sui-dropdown-header>
+            <router-link class="item" to="/questions">Questions</router-link>
+            <router-link class="item" to="/logos">Logos</router-link>
+
+            <sui-dropdown-divider />
+            <sui-dropdown-header>Personalize</sui-dropdown-header>
+
+            <router-link class="item" to="/insights">Insights</router-link>
+            <router-link class="item" to="/settings">Settings</router-link>
+          </sui-dropdown-menu>
+        </sui-dropdown>
+
+        <sui-menu-menu position="right">
+          <router-link class="item" to="/settings">
+            <sui-icon name="cog" />
+          </router-link>
+        </sui-menu-menu>
+      </sui-menu>
     </div>
+
     <router-view />
   </div>
 </template>
@@ -17,3 +36,9 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+.menu-container {
+  margin-bottom: 1rem;
+}
+</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,18 +9,12 @@
             <router-link class="item" to="/logos">Logos</router-link>
 
             <sui-dropdown-divider />
-            <sui-dropdown-header>Personalize</sui-dropdown-header>
+            <sui-dropdown-header>Manage</sui-dropdown-header>
 
             <router-link class="item" to="/insights">Insights</router-link>
             <router-link class="item" to="/settings">Settings</router-link>
           </sui-dropdown-menu>
         </sui-dropdown>
-
-        <sui-menu-menu position="right">
-          <router-link class="item" to="/settings">
-            <sui-icon name="cog" />
-          </router-link>
-        </sui-menu-menu>
       </sui-menu>
     </div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,9 @@ import LogoSearchView from './views/LogoSearchView.vue'
 import LogoAnnotationView from './views/LogoAnnotationView.vue'
 import LogoUpdateView from './views/LogoUpdateView.vue'
 import 'viewerjs/dist/viewer.css'
+import SuiVue from 'semantic-ui-vue'
 
+Vue.use(SuiVue)
 Vue.use(VueRouter)
 Vue.use(Viewer)
 Vue.config.productionTip = false
@@ -28,8 +30,6 @@ const routes = [
 const router = new VueRouter({
   mode: 'history',
   routes,
-  linkActiveClass: "partial-active",
-  linkExactActiveClass: "active",
 });
 new Vue({
   router,


### PR DESCRIPTION
Add a link to logo page to fill solve #40 

In order to become mobile-friendly, I put it into a drop-down menu (otherwise menu would become too large).

To do so, I added the library "Semantic UI Vue". Say me if you're okay with that or not

![image](https://user-images.githubusercontent.com/45398769/85949185-a0d69e80-b955-11ea-951c-66828ff7de0d.png)
