### PR TITLE
Add store logo type

### DIFF
--- a/src/views/LogoAnnotationView.vue
+++ b/src/views/LogoAnnotationView.vue
@@ -17,6 +17,7 @@
               <option value="qr_code">QR code</option>
               <option value="category">Category</option>
               <option value="nutrition_label">Nutrition label</option>
+              <option value="store">Store</option>
             </select>
           </div>
           <div class="field">

--- a/src/views/LogoSearchView.vue
+++ b/src/views/LogoSearchView.vue
@@ -21,6 +21,7 @@
               <option value="qr_code">QR code</option>
               <option value="category">Category</option>
               <option value="nutrition_label">Nutrition label</option>
+              <option value="store">Store</option>
             </select>
           </div>
           <div class="field">

--- a/src/views/LogoUpdateView.vue
+++ b/src/views/LogoUpdateView.vue
@@ -21,6 +21,7 @@
               <option value="brand">Brand</option>
               <option value="packager_code">Packager code</option>
               <option value="qr_code">QR code</option>
+              <option value="store">Store</option>
             </select>
           </div>
           <div class="field">


### PR DESCRIPTION
Enables pure store logos that should not be used as brands to be labelled as such. Examples would include stores like LIDL, REWE or Edeka, which quite often have their store logos on their store brands.