### PR TITLE
Better logos visualization on mobile landscape and portrait modes

### DIFF
--- a/src/components/LogoCardGrid.vue
+++ b/src/components/LogoCardGrid.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="ui grid">
       <div
-        class="five wide mobile four wide tablet three wide computer column"
+        class="four wide mobile-landscape eight wide mobile four wide tablet three wide computer column"
         v-for="logo in logos"
         :key="logo.id"
       >
@@ -80,5 +80,13 @@ export default {
 .ann-logo.annotated {
   background-color: #797979;
   color: #ffffff;
+}
+
+@media only screen
+and (max-width: 767px)
+and (orientation: landscape) {
+  .ui.grid>[class*="four wide mobile-landscape"].column {
+    width: 25%!important;
+  }
 }
 </style>

--- a/src/components/LogoCardGrid.vue
+++ b/src/components/LogoCardGrid.vue
@@ -24,7 +24,7 @@
             </div>
           </div>
           <div class="image">
-            <img width="100px" loading="lazy" :src="logo.image.url" />
+            <img loading="lazy" :src="logo.image.url" />
           </div>
           <div class="content">
             <p v-if="logo.distance">{{$t("logos.distance")}} {{ logo.distance.toFixed(1) }}</p>
@@ -80,6 +80,15 @@ export default {
 .ann-logo.annotated {
   background-color: #797979;
   color: #ffffff;
+}
+
+.ui.card>.image {
+  display: flex;
+  justify-content: center;
+}
+
+.ui.card>.image>img {
+  max-width: 100%;
 }
 
 @media only screen

--- a/src/components/LogoCardGrid.vue
+++ b/src/components/LogoCardGrid.vue
@@ -11,7 +11,7 @@
           @click="toggleSelectLogo(logo)"
           :class="{selected: logo.selected, annotated: logo.annotation_type }"
         >
-          <div class="content">
+          <div class="content actions">
             <div class="left floated meta">
               <router-link :to="editLogoURL(logo)" target="_blank">
                 <i class="edit icon"></i>
@@ -23,10 +23,10 @@
               </router-link>
             </div>
           </div>
-          <div class="image">
+          <div class="content logo-image">
             <img loading="lazy" :src="logo.image.url" />
           </div>
-          <div class="content">
+          <div class="content distance">
             <p v-if="logo.distance">{{$t("logos.distance")}} {{ logo.distance.toFixed(1) }}</p>
             <p
               v-if="logo.annotation_value"
@@ -82,13 +82,23 @@ export default {
   color: #ffffff;
 }
 
-.ui.card>.image {
+.ui.card>.actions {
+  flex-grow: 0;
+}
+
+.ui.card>.logo-image {
   display: flex;
+  align-items: center;
+  flex-grow: 1;
   justify-content: center;
 }
 
-.ui.card>.image>img {
+.ui.card>.logo-image>img {
   max-width: 100%;
+}
+
+.ui.card>.distance {
+  flex-grow: 0;
 }
 
 @media only screen

--- a/src/components/LogoCardGrid.vue
+++ b/src/components/LogoCardGrid.vue
@@ -19,7 +19,7 @@
             </div>
             <div class="right floated meta">
               <router-link :to="externalLogoURL(logo)" target="_blank">
-                <i class="external alternate icon small blue"></i>
+                <i class="external alternate icon blue"></i>
               </router-link>
             </div>
           </div>

--- a/src/components/LogoCardGrid.vue
+++ b/src/components/LogoCardGrid.vue
@@ -81,6 +81,9 @@ export default {
   background-color: #797979;
   color: #ffffff;
 }
+.ui.card {
+  height: 100%;
+}
 
 .ui.card>.actions {
   flex-grow: 0;


### PR DESCRIPTION
Logos are now displayed on 2 columns in portrait mode and 4 columns in landscape mode on mobile devices

![image](https://user-images.githubusercontent.com/537363/88058474-cf662480-cb63-11ea-9359-48678c83670f.png)
![image](https://user-images.githubusercontent.com/537363/88058513-dab95000-cb63-11ea-8d2b-155dc7b51935.png)

