### PR TITLE
chore: group API calls

### DIFF
--- a/src/components/AnnotationCounter.vue
+++ b/src/components/AnnotationCounter.vue
@@ -24,8 +24,7 @@
 </template>
 
 <script>
-import axios from "axios";
-import { ROBOTOFF_API_URL } from "../const";
+import robotoffService from "../robotoff";
 import { getUsername } from "../off";
 import { getProductUrl } from "../off";
 
@@ -67,8 +66,8 @@ export default {
   },
   mounted() {
     if (this.username.length) {
-      axios
-        .get(`${ROBOTOFF_API_URL}/users/statistics/${this.username}`)
+      robotoffService
+        .getUserStatistics(this.username)
         .then(result => {
           this.historyAnnotatedCount = result.data.count.annotations;
         })

--- a/src/components/AnnotationCounter.vue
+++ b/src/components/AnnotationCounter.vue
@@ -25,8 +25,7 @@
 
 <script>
 import robotoffService from "../robotoff";
-import { getUsername } from "../off";
-import { getProductUrl } from "../off";
+import offService from "../off";
 
 export default {
   name: "AnnotationCounter",
@@ -46,13 +45,13 @@ export default {
   },
   data: function() {
     return {
-      username: getUsername(),
+      username: offService.getUsername(),
       historyAnnotatedCount: 0
     };
   },
   methods: {
     getProductUrl: function(barcode) {
-      return getProductUrl(barcode);
+      return offService.getProductUrl(barcode);
     }
   },
   computed: {

--- a/src/components/Product.vue
+++ b/src/components/Product.vue
@@ -36,10 +36,8 @@
 </template>
 
 <script>
-import axios from "axios";
-import { OFF_API_URL, OFF_IMAGE_URL } from "../const";
 import { countryMap } from "../countries";
-import { getProductUrl, getProductEditUrl } from "../off";
+import offService from "../off";
 
 const BARCODE_REGEX = /(...)(...)(...)(.*)$/;
 const splitBarcode = barcode => {
@@ -59,7 +57,7 @@ const getImageRootURL = barcode => {
   if (splittedBarcode === null) {
     return null;
   }
-  return `${OFF_IMAGE_URL}/${splittedBarcode.join("/")}`;
+  return offService.getImageUrl(splittedBarcode.join("/"));
 };
 
 export default {
@@ -98,10 +96,8 @@ export default {
   },
   methods: {
     update: function() {
-      axios
-        .get(
-          `${OFF_API_URL}/product/${this.barcode}.json?fields=product_name,brands,ingredients_text,countries_tags,images`
-        )
+      offService
+        .getProduct(this.barcode)
         .then(result => {
           const product = result.data.product;
           this.productName = product.product_name || "";
@@ -125,13 +121,13 @@ export default {
       if (this.barcode === null) {
         return "";
       }
-      return getProductUrl(this.barcode);
+      return offService.getProductUrl(this.barcode);
     },
     productEditUrl: function() {
       if (this.barcode === null) {
         return "";
       }
-      return getProductEditUrl(this.barcode);
+      return offService.getProductEditUrl(this.barcode);
     },
     countries: function() {
       return this.countriesTags.map(c => countryMap[c]).join(", ");

--- a/src/off.js
+++ b/src/off.js
@@ -1,40 +1,56 @@
 import { getLang } from "./settings";
+import { OFF_API_URL, OFF_IMAGE_URL } from "./const"
+import axios from 'axios';
+import combineURLs from 'axios/lib/helpers/combineURLs';
 
-export const getCookie = name => {
+
+export default {
+  getCookie(name) {
     const cookies = document.cookie.split(';').filter((item) => item.trim().startsWith(`${name}=`));
     if (cookies.length) {
-        const cookie = cookies[0];
-        return cookie.split("=", 2)[1];
+      const cookie = cookies[0];
+      return cookie.split("=", 2)[1];
     }
     return "";
-}
+  },
 
-export const getUsername = () => {
-    const sessionCookie = getCookie("session");
+  getUsername() {
+    const sessionCookie = this.getCookie("session");
 
     if (!sessionCookie.length) {
-        return "";
+      return "";
     }
 
     let isNext = false;
     let username = "";
     sessionCookie.split("&").forEach(el => {
-        if (el === "user_id") {
-            isNext = true;
-        } else if (isNext) {
-            username = el;
-            isNext = false;
-        }
+      if (el === "user_id") {
+        isNext = true;
+      } else if (isNext) {
+        username = el;
+        isNext = false;
+      }
     });
     return username;
-}
+  },
 
-export const getProductUrl = barcode => {
+  getProduct(barcode) {
+    return axios.get(
+      `${OFF_API_URL}/product/${barcode}.json?fields=product_name,brands,ingredients_text,countries_tags,images`
+    )
+  },
+
+  getProductUrl(barcode) {
     const lang = getLang();
     return `https://world${lang === 'en' ? '' : '-' + lang}.openfoodfacts.org/product/${barcode}`
-}
+  },
 
-export const getProductEditUrl = barcode => {
+  getProductEditUrl(barcode) {
     const lang = getLang();
     return `https://world${lang === 'en' ? '' : '-' + lang}.openfoodfacts.org/cgi/product.pl?type=edit&code=${barcode}`;
+  },
+
+  getImageUrl(imagePath) {
+    return combineURLs(OFF_IMAGE_URL, imagePath)
+  }
 }

--- a/src/robotoff.js
+++ b/src/robotoff.js
@@ -15,14 +15,74 @@ export default {
     )
   },
 
-  questions(sortBy, insight_types, value_tag, brands, country, count=10) {
+  questions(sortBy, insightTypes, valueTag, brands, country, count=10) {
     const lang = getLang();
     return axios.get(
       `${ROBOTOFF_API_URL}/questions/${sortBy}`, {
         params : removeEmptyKeys({
-          count, lang, insight_types, value_tag, brands, country
+          count, lang, insight_types: insightTypes, value_tag: valueTag, brands, country
         })
       }
+    )
+  },
+
+  loadLogo(logoId) {
+    return axios.get(
+      `${ROBOTOFF_API_URL}/images/logos/${logoId}`
+    )
+  },
+
+  updateLogo(logoId, value, type) {
+    return axios.put(
+      `${ROBOTOFF_API_URL}/images/logos/${logoId}`, {
+        params : removeEmptyKeys({
+          withCredentials: true, value, type
+        })
+      }
+    )
+  },
+
+  searchLogos(barcode, value, type, count=25) {
+    return axios.get(
+      `${ROBOTOFF_API_URL}/images/logos`, {
+        params : removeEmptyKeys({
+          annotated: 1, barcode, value, type, count
+        })
+      }
+    )
+  },
+
+  getLogoAnnotations(logoId, index, count) {
+    const url = logoId.length > 0
+        ? `${ROBOTOFF_API_URL}/ann/${logoId}`
+        : `${ROBOTOFF_API_URL}/ann`;
+    return axios.get(
+      url, {
+        params : removeEmptyKeys({
+          index, count
+        })
+      }
+    )
+  },
+
+  annotateLogos(annotations) {
+    return axios.post(
+      `${ROBOTOFF_API_URL}/images/logos/annotate`, {
+        params : removeEmptyKeys({
+          withCredentials: true, annotations,
+        })
+      }
+    )
+  },
+
+  getCroppedImageUrl(imageUrl, boundingBox) {
+    const [y_min, x_min, y_max, x_max] = boundingBox;
+    return `${ROBOTOFF_API_URL}/images/crop?image_url=${imageUrl}&y_min=${y_min}&x_min=${x_min}&y_max=${y_max}&x_max=${x_max}`;
+  },
+
+  getLogosImages(logoIds) {
+    return axios.get(
+      `${ROBOTOFF_API_URL}/images/logos?logo_ids=${logoIds.join(",")}`
     )
   }
 }

--- a/src/robotoff.js
+++ b/src/robotoff.js
@@ -75,6 +75,22 @@ export default {
     )
   },
 
+  getInsights(barcode, insightTypes, valueTag, annotation, page, count=25) {
+    let annotated
+    if (annotation.length && annotation == "not_annotated") {
+      annotated = "0";
+    }
+    return axios.get(
+      `${ROBOTOFF_API_URL}/insights`, {
+        params : removeEmptyKeys({
+          barcode, insight_types: insightTypes,
+          value_tag: valueTag, annotation, page,
+          annotated, count
+        })
+      }
+    )
+  },
+
   getCroppedImageUrl(imageUrl, boundingBox) {
     const [y_min, x_min, y_max, x_max] = boundingBox;
     return `${ROBOTOFF_API_URL}/images/crop?image_url=${imageUrl}&y_min=${y_min}&x_min=${x_min}&y_max=${y_max}&x_max=${x_max}`;

--- a/src/robotoff.js
+++ b/src/robotoff.js
@@ -1,12 +1,28 @@
 import axios from 'axios';
 import { ROBOTOFF_API_URL } from "./const"
+import { getLang } from "./settings";
+import {removeEmptyKeys} from './utils'
 
-export const annotate = (insightId, annotation) => {
+export default {
+
+  annotate(insightId, annotation) {
     return axios.post(
         `${ROBOTOFF_API_URL}/insights/annotate`,
         new URLSearchParams(
             `insight_id=${insightId}&annotation=${annotation}&update=1`,
         ),
         { withCredentials: true },
-    );
-};
+    )
+  },
+
+  questions(sortBy, insight_types, value_tag, brands, country, count=10) {
+    const lang = getLang();
+    return axios.get(
+      `${ROBOTOFF_API_URL}/questions/${sortBy}`, {
+        params : removeEmptyKeys({
+          count, lang, insight_types, value_tag, brands, country
+        })
+      }
+    )
+  }
+}

--- a/src/robotoff.js
+++ b/src/robotoff.js
@@ -91,6 +91,10 @@ export default {
     )
   },
 
+  getUserStatistics(username) {
+    return axios.get(`${ROBOTOFF_API_URL}/users/statistics/${username}`)
+  },
+
   getCroppedImageUrl(imageUrl, boundingBox) {
     const [y_min, x_min, y_max, x_max] = boundingBox;
     return `${ROBOTOFF_API_URL}/images/crop?image_url=${imageUrl}&y_min=${y_min}&x_min=${x_min}&y_max=${y_max}&x_max=${x_max}`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,3 +7,10 @@ export const getURLParam = key => {
 
     return urlParams.get(key);
 };
+
+export const removeEmptyKeys = obj => {
+  Object.keys(obj).forEach(
+    key => (obj[key] === undefined || obj[key] === '') && delete obj[key]
+  )
+  return obj
+}

--- a/src/views/InsightListView.vue
+++ b/src/views/InsightListView.vue
@@ -85,8 +85,7 @@
 </template>
 
 <script>
-import axios from "axios";
-import { ROBOTOFF_API_URL } from "../const";
+import robotoffService from "../robotoff";
 import Pagination from "../components/Pagination";
 
 export default {
@@ -128,32 +127,15 @@ export default {
       this.loadInsights();
     },
     loadInsights: function() {
-      const params = {
-        page: this.currentPage,
-        count: this.pageSize
-      };
-
-      if (this.barcodeFilter.length) {
-        params.barcode = this.barcodeFilter;
-      }
-      if (this.insightTypeFilter.length) {
-        params.insight_types = this.insightTypeFilter;
-      }
-      if (this.valueTagFilter.length) {
-        params.value_tag = this.valueTagFilter;
-      }
-
-      if (this.annotationFilter.length) {
-        if (this.annotationFilter == "not_annotated") {
-          params.annotated = "0";
-        } else {
-          params.annotation = this.annotationFilter;
-        }
-      }
-      axios.get(`${ROBOTOFF_API_URL}/insights`, { params }).then(result => {
-        this.insights = result.data.insights;
-        this.resultCount = result.data.count;
-      });
+      robotoffService
+        .getInsights(
+          this.barcodeFilter, this.insightTypeFilter, this.valueTagFilter,
+          this.annotationFilter, this.currentPage, this.pageSize
+        )
+        .then(result => {
+          this.insights = result.data.insights;
+          this.resultCount = result.data.count;
+        });
     }
   },
   mounted() {

--- a/src/views/LogoAnnotationView.vue
+++ b/src/views/LogoAnnotationView.vue
@@ -108,7 +108,6 @@ export default {
   },
   methods: {
     loadLogos: function() {
-
       robotoffService
         .getLogoAnnotations(this.targetLogoId, getURLParam("index"), this.annCount)
         .then(({ data }) => {

--- a/src/views/LogoAnnotationView.vue
+++ b/src/views/LogoAnnotationView.vue
@@ -56,13 +56,13 @@
 
 <script>
 import robotoffService from "../robotoff";
-import { OFF_IMAGE_URL } from "../const";
+import offService from "../off";
 import LogoCardGrid from "../components/LogoCardGrid";
 import { getURLParam } from "../utils";
 
 const transformLogo = logo => {
   logo.image.url = robotoffService.getCroppedImageUrl(
-    `${OFF_IMAGE_URL}${logo.image.source_image}`, logo.bounding_box
+    offService.getImageUrl(logo.image.source_image), logo.bounding_box
   )
   logo.selected = false;
   return logo;

--- a/src/views/LogoSearchView.vue
+++ b/src/views/LogoSearchView.vue
@@ -47,14 +47,15 @@
 </template>
 
 <script>
-import axios from "axios";
-import { ROBOTOFF_API_URL, OFF_IMAGE_URL } from "../const";
+import robotoffService from "../robotoff";
+import { OFF_IMAGE_URL } from "../const";
 import LogoCardGrid from "../components/LogoCardGrid";
 
 const transformLogo = logo => {
-  const imageUrl = `${OFF_IMAGE_URL}${logo.image.source_image}`;
-  const [y_min, x_min, y_max, x_max] = logo.bounding_box;
-  logo.image.url = `${ROBOTOFF_API_URL}/images/crop?image_url=${imageUrl}&y_min=${y_min}&x_min=${x_min}&y_max=${y_max}&x_max=${x_max}`;
+  logo.image.url = robotoffService.getCroppedImageUrl(
+    `${OFF_IMAGE_URL}${logo.image.source_image}`,
+    logo.bounding_box
+  )
   return logo;
 };
 
@@ -74,28 +75,12 @@ export default {
   computed: {},
   methods: {
     search: function() {
-      const url = `${ROBOTOFF_API_URL}/images/logos`;
-      const params = {
-        count: this.count,
-        annotated: 1
-      };
-
-      if (this.barcode) {
-        params.barcode = this.barcode;
-      }
-
-      if (this.value) {
-        params.value = this.value;
-      }
-
-      if (this.type) {
-        params.type = this.type;
-      }
-
-      axios.get(url, { params }).then(({ data }) => {
-        this.logos = data.logos.map(transformLogo);
-        this.resultCount = data.count;
-      });
+      robotoffService
+        .searchLogos(this.barcode, this.value, this.type, this.count)
+        .then(({ data }) => {
+          this.logos = data.logos.map(transformLogo);
+          this.resultCount = data.count;
+        });
     }
   },
   mounted() {

--- a/src/views/LogoSearchView.vue
+++ b/src/views/LogoSearchView.vue
@@ -48,12 +48,12 @@
 
 <script>
 import robotoffService from "../robotoff";
-import { OFF_IMAGE_URL } from "../const";
+import offService from "../off";
 import LogoCardGrid from "../components/LogoCardGrid";
 
 const transformLogo = logo => {
   logo.image.url = robotoffService.getCroppedImageUrl(
-    `${OFF_IMAGE_URL}${logo.image.source_image}`,
+    offService.getImageUrl(logo.image.source_image),
     logo.bounding_box
   )
   return logo;

--- a/src/views/LogoUpdateView.vue
+++ b/src/views/LogoUpdateView.vue
@@ -38,9 +38,9 @@
 
 <script>
 import robotoffService from "../robotoff";
-import { OFF_IMAGE_URL } from "../const";
+import offService from "../off";
 
-const getImageURL = logo => `${OFF_IMAGE_URL}${logo.image.source_image}`;
+const getImageURL = logo => offService.getImageUrl(logo.image.source_image);
 
 const getCropURL = logo => {
   return robotoffService.getCroppedImageUrl(

--- a/src/views/LogoUpdateView.vue
+++ b/src/views/LogoUpdateView.vue
@@ -37,15 +37,15 @@
 </template>
 
 <script>
-import axios from "axios";
-import { ROBOTOFF_API_URL, OFF_IMAGE_URL } from "../const";
+import robotoffService from "../robotoff";
+import { OFF_IMAGE_URL } from "../const";
 
 const getImageURL = logo => `${OFF_IMAGE_URL}${logo.image.source_image}`;
 
 const getCropURL = logo => {
-  const imageUrl = getImageURL(logo);
-  const [y_min, x_min, y_max, x_max] = logo.bounding_box;
-  return `${ROBOTOFF_API_URL}/images/crop?image_url=${imageUrl}&y_min=${y_min}&x_min=${x_min}&y_max=${y_max}&x_max=${x_max}`;
+  return robotoffService.getCroppedImageUrl(
+    getImageURL(logo), logo.bounding_box
+  )
 };
 
 export default {
@@ -67,8 +67,8 @@ export default {
   },
   methods: {
     loadLogo: function() {
-      axios
-        .get(`${ROBOTOFF_API_URL}/images/logos/${this.logoId}`)
+      robotoffService
+        .loadLogo(this.logoId)
         .then(({ data }) => {
           this.imageURL = getImageURL(data);
           this.cropURL = getCropURL(data);
@@ -79,7 +79,6 @@ export default {
     },
     updateLogo: function() {
       if (this.annotationType.length == 0) return;
-
       let value = this.annotationValue.toLowerCase();
       if (
         this.annotationType === "packager_code" ||
@@ -87,14 +86,8 @@ export default {
       ) {
         value = "";
       }
-      const params = {
-        value: value,
-        type: this.annotationType
-      };
-      axios
-        .put(`${ROBOTOFF_API_URL}/images/logos/${this.logoId}`, params, {
-          withCredentials: true
-        })
+      robotoffService
+        .updateLogo(this.logoId, value, this.annotationType)
         .then(() => {
           window.console.log("Updated!");
         });

--- a/src/views/QuestionView.vue
+++ b/src/views/QuestionView.vue
@@ -97,10 +97,7 @@
 </template>
 
 <script>
-import axios from "axios";
-import { getLang } from "../settings";
-import { ROBOTOFF_API_URL } from "../const";
-import { annotate as robotoffAnnotate } from "../robotoff";
+import robotoffService from "../robotoff";
 import Product from "../components/Product";
 import AnnotationCounter from "../components/AnnotationCounter";
 
@@ -289,7 +286,7 @@ export default {
     },
     annotate: function(annotation) {
       if (annotation !== -1) {
-        robotoffAnnotate(this.currentQuestion.insight_id, annotation);
+        robotoffService.annotate(this.currentQuestion.insight_id, annotation);
         this.updateLastAnnotations(this.currentQuestion, annotation);
         this.remainingQuestionCount -= 1;
         this.sessionAnnotatedCount += 1;
@@ -314,32 +311,14 @@ export default {
       }
     },
     loadQuestions: function() {
-      const count = 10;
-      const lang = getLang();
       const sortBy = this.sortByPopularity ? "popular" : "random";
-
-      const params = {
-        lang,
-        count,
-        insight_types: this.selectedInsightType
-      };
-
-      if (this.valueTag) {
-        params.value_tag = this.valueTag;
-      }
-
-      if (this.brandFilter.length) {
-        params.brands = this.brandFilter;
-      }
-
-      if (this.countryFilter.length) {
-        params.country = this.countryFilter;
-      }
-
-      axios
-        .get(`${ROBOTOFF_API_URL}/questions/${sortBy}`, {
-          params
-        })
+      const count = 10;
+      robotoffService
+        .questions(
+          sortBy, this.selectedInsightType,
+          this.valueTag, this.brandFilter,
+          this.countryFilter, count
+        )
         .then(result => {
           this.remainingQuestionCount = result.data.count;
           if (result.data.questions.length == 0) {
@@ -373,7 +352,6 @@ export default {
       if (this.currentQuestion.source_image_url) {
         return this.currentQuestion.source_image_url;
       }
-
       return "https://static.openfoodfacts.org/images/image-placeholder.png";
     },
     imageRotationClassName: function() {


### PR DESCRIPTION
This refactoring aims to group all the API calls in a multiple client modules (`robotoff` and `off`). I recommend to use this abstraction so that we only have to touch one file if we have to change the way to fetch data in the future.