### PR TITLE
feat: show annotation type for annotations that don't take a value

### DIFF
--- a/src/components/LogoCardGrid.vue
+++ b/src/components/LogoCardGrid.vue
@@ -31,6 +31,9 @@
             <p
               v-if="logo.annotation_value"
             >{{$t("logos.annotation")}}{{ logo.annotation_value }} ({{ logo.annotation_type }})</p>
+            <p
+              v-else-if="logo.annotation_type"
+            >{{$t("logos.annotation")}}({{ logo.annotation_type }})</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
It'd be more obvious that "grey box = already annotated" if they all said so. And it'd be nice to see what all the annotations were, not just the textual ones. E.g.
![image](https://user-images.githubusercontent.com/5736616/93189824-87661700-f73a-11ea-82a5-51ff334a9e38.png)

(Caveat: I don't know this language/templating system, I'm getting the syntax from https://vuejs.org/v2/guide/conditional.html)