### PR TITLE
feat: Support 'no logo' annotation

### DIFF
--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -83,7 +83,7 @@
     "no_found": "No logo found",
     "search": "Search",
     "number_of_results": "Number of results:",
-    "no_logo": "Not a logo"
+    "other": "Other"
   },
   "settings": {
     "settings": "Settings",

--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -82,7 +82,8 @@
     "update": "Update",
     "no_found": "No logo found",
     "search": "Search",
-    "number_of_results": "Number of results:"
+    "number_of_results": "Number of results:",
+    "no_logo": "Not a logo"
   },
   "settings": {
     "settings": "Settings",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -82,7 +82,8 @@
     "update": "Update",
     "no_found": "No logo found",
     "search": "Search",
-    "number_of_results": "Number of results:"
+    "number_of_results": "Number of results:",
+    "other": "Other"
   },
     "nutrition": {
     "present": "Specified on product",

--- a/src/views/LogoAnnotationView.vue
+++ b/src/views/LogoAnnotationView.vue
@@ -19,6 +19,7 @@
               <option value="category">{{$t("logos.category")}}</option>
               <option value="nutrition_label">{{$t("logos.nutrition_label")}}</option>
               <option value="store">{{$t("logos.store")}}</option>
+              <option value="no_logo">{{$t("logos.no_logo")}}</option>
             </select>
           </div>
           <div class="field">
@@ -147,7 +148,7 @@ export default {
     sendAnnotations: function() {
       let value = this.valueInput.toLowerCase();
 
-      if (this.typeInput === "packager_code" || this.typeInput === "qr_code") {
+      if (this.typeInput === "packager_code" || this.typeInput === "qr_code" || this.typeInput === "no_logo") {
         value = "";
       }
       const annotations = this.selectedLogos.map(logo => ({

--- a/src/views/LogoAnnotationView.vue
+++ b/src/views/LogoAnnotationView.vue
@@ -19,7 +19,7 @@
               <option value="category">{{$t("logos.category")}}</option>
               <option value="nutrition_label">{{$t("logos.nutrition_label")}}</option>
               <option value="store">{{$t("logos.store")}}</option>
-              <option value="no_logo">{{$t("logos.no_logo")}}</option>
+              <option value="other">{{$t("logos.other")}}</option>
             </select>
           </div>
           <div class="field">
@@ -148,7 +148,7 @@ export default {
     sendAnnotations: function() {
       let value = this.valueInput.toLowerCase();
 
-      if (this.typeInput === "packager_code" || this.typeInput === "qr_code" || this.typeInput === "no_logo") {
+      if (this.typeInput === "packager_code" || this.typeInput === "qr_code") {
         value = "";
       }
       const annotations = this.selectedLogos.map(logo => ({

--- a/src/views/LogoSearchView.vue
+++ b/src/views/LogoSearchView.vue
@@ -22,6 +22,7 @@
               <option value="category">{{$t("logos.category")}}</option>
               <option value="nutrition_label">{{$t("logos.nutrition_label")}}</option>
               <option value="store">{{$t("logos.store")}}</option>
+              <option value="no_logo">{{$t("logos.no_logo")}}</option>
             </select>
           </div>
           <div class="field">

--- a/src/views/LogoSearchView.vue
+++ b/src/views/LogoSearchView.vue
@@ -22,7 +22,7 @@
               <option value="category">{{$t("logos.category")}}</option>
               <option value="nutrition_label">{{$t("logos.nutrition_label")}}</option>
               <option value="store">{{$t("logos.store")}}</option>
-              <option value="no_logo">{{$t("logos.no_logo")}}</option>
+              <option value="other">{{$t("logos.other")}}</option>
             </select>
           </div>
           <div class="field">

--- a/src/views/LogoUpdateView.vue
+++ b/src/views/LogoUpdateView.vue
@@ -25,7 +25,7 @@
               <option value="category">{{$t("logos.category")}}</option>
               <option value="nutrition_label">{{$t("logos.nutrition_label")}}</option>
               <option value="store">{{$t("logos.store")}}</option>
-              <option value="no_logo">{{$t("logos.no_logo")}}</option>
+              <option value="other">{{$t("logos.other")}}</option>
             </select>
           </div>
           <div class="field">
@@ -91,8 +91,7 @@ export default {
       let value = this.annotationValue.toLowerCase();
       if (
         this.annotationType === "packager_code" ||
-        this.annotationType === "qr_code" ||
-        this.annotationType === "no_logo"
+        this.annotationType === "qr_code"
       ) {
         value = "";
       }

--- a/src/views/LogoUpdateView.vue
+++ b/src/views/LogoUpdateView.vue
@@ -25,6 +25,7 @@
               <option value="category">{{$t("logos.category")}}</option>
               <option value="nutrition_label">{{$t("logos.nutrition_label")}}</option>
               <option value="store">{{$t("logos.store")}}</option>
+              <option value="no_logo">{{$t("logos.no_logo")}}</option>
             </select>
           </div>
           <div class="field">
@@ -90,7 +91,8 @@ export default {
       let value = this.annotationValue.toLowerCase();
       if (
         this.annotationType === "packager_code" ||
-        this.annotationType === "qr_code"
+        this.annotationType === "qr_code" ||
+        this.annotationType === "no_logo"
       ) {
         value = "";
       }


### PR DESCRIPTION
### What
Some logos like [Ingrédients](https://hunger.openfoodfacts.org/logos?logo_id=507646) are actually not logos in any way that is currently supported for annotations. Allowing users to state that layout elements like this are not actually logos could avoid incorrect classifications of these in the future.

### Part of
- #235 