### PR TITLE
set the app in 404.html too

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           npm install --legacy-peer-deps
           npm run build
+          npm run deploy
 
         # --legacy-peer-deps is used due to a dependency between "@vue/cli-plugin-eslint" and eslint
       - name: Deploy 🚀

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "deploy": "cd dist && cp index.html 404.html && cd .."
   },
   "dependencies": {
     "@yaireo/tagify": "^4.7.2",

--- a/src/main.js
+++ b/src/main.js
@@ -48,9 +48,7 @@ const routes = [
 ];
 
 const router = new VueRouter({
-  // Using "hash" allows us to deploy with gh-pages
-  //https://stackoverflow.com/questions/38658363/gh-pages-share-index-html-for-all-routes
-  mode: 'hash',
+  mode: "history",
   routes,
 });
 


### PR DESCRIPTION
using hash vue-router-history leads to modifications of urls more over it is not easy to deal with `URLSearchParams`.

So I choose the easiest solution : the 404 page is also the app, such that we do not need anymore to use hash router