### PR TITLE
feat: allows to massively accept robotoff insights

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import LogoSearchView from "./views/LogoSearchView.vue";
 import LogoAnnotationView from "./views/LogoAnnotationView.vue";
 import LogoUpdateView from "./views/LogoUpdateView.vue";
 import EcoScoreMenu from "./views/EcoScoreMenu.vue";
+import SecretTool from "./views/secretTool.vue";
 import "viewerjs/dist/viewer.css";
 import SuiVue from "semantic-ui-vue";
 import messages from "./i18n/messages";
@@ -39,6 +40,7 @@ const routes = [
   { path: "/insights", component: InsightListView },
   { path: "/questions", component: QuestionView },
   { path: "/eco-score", component: EcoScoreMenu },
+  { path: "/secretTool", component: SecretTool },
   { path: "/nutritions", component: NutritionView },
   { path: "/nutritionInteractive", component: NutritionInteractiveView },
   { path: "/nutritionInteractive/:code", component: NutritionInteractiveView },

--- a/src/views/secretTool.vue
+++ b/src/views/secretTool.vue
@@ -1,0 +1,164 @@
+<template>
+  <div class="ui">
+    <div v-if="loading"><LoadingSpinner show /></div>
+    <div v-else-if="noRemainingQuestion">No more questions</div>
+    <div v-else>
+      <h3>
+        {{ questions[0].question }}
+        <!-- <img :src="questions[0].image_url" /> -->
+        <span class="ui big label">{{ questions[0].value }}</span>
+      </h3>
+      <div class="ui grid stackable">
+        <div
+          class="ui"
+          v-for="question in questions"
+          :key="question.insight_id"
+          @click="toggle(question.insight_id)"
+          :class="{ selected: question.selected }"
+        >
+          <img :src="question.source_image_url" />
+          <div v-if="question.selected" class="filter"></div>
+        </div>
+      </div>
+      <button class="ui big positive button validateButton" @click="validate()">
+        <i class="check icon"></i>
+        {{ nbSelected }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import robotoffService from "../robotoff";
+import LoadingSpinner from "../components/LoadingSpinner";
+
+const NO_QUESTION_LEFT = "NO_QUESTION_LEFT";
+const LOADING = "LOADING";
+
+export default {
+  name: "QuestionView",
+  components: { LoadingSpinner },
+  data: function() {
+    return {
+      status: LOADING,
+      questions: [],
+    };
+  },
+  methods: {
+    validate() {
+      this.questions.forEach(({ insight_id, selected }) => {
+        if (selected === true) {
+          robotoffService.annotate(insight_id, 1);
+        }
+      });
+      this.questions = [];
+      this.fetchNewQuestions();
+    },
+    toggle(insight_id) {
+      this.questions = this.questions.map((x) =>
+        x.insight_id === insight_id ? { ...x, selected: !x.selected } : x
+      );
+    },
+    fetchNewQuestions() {
+      this.status = LOADING;
+      const count = 100;
+      robotoffService
+        .questions("random", "label", "en:eu-organic", null, null, count)
+        .then((result) => {
+          if (result.data.questions.length == 0) {
+            this.status = NO_QUESTION_LEFT;
+            return;
+          }
+          const refQuestion =
+            this.questions.length > 0
+              ? this.questions[0].question
+              : result.data.questions[0].question;
+          const refValue =
+            this.questions.length > 0
+              ? this.questions[0].value
+              : result.data.questions[0].value;
+          const indsighIdAlreadyInQuestions = this.questions.map(
+            ({ insight_id }) => insight_id
+          );
+
+          this.questions = [
+            ...this.questions,
+            ...result.data.questions.filter(
+              ({ insight_id, question, value }) =>
+                !indsighIdAlreadyInQuestions.includes(insight_id) &&
+                refValue === value &&
+                refQuestion === question
+            ),
+          ];
+          this.status = "done";
+        });
+    },
+  },
+  computed: {
+    loading: function() {
+      return this.status === LOADING && this.questions.length === 0;
+    },
+    noRemainingQuestion: function() {
+      return this.status === NO_QUESTION_LEFT;
+    },
+    nbSelected: function() {
+      return this.questions.filter((x) => x.selected === true).length;
+    },
+  },
+  mounted() {
+    this.fetchNewQuestions();
+  },
+};
+</script>
+
+<style scoped>
+.filter {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 255, 0, 0.3);
+}
+h3 {
+  margin-bottom: 4rem;
+  text-align: center;
+}
+.selected {
+  position: relative;
+}
+.selected img {
+  filter: url("#teal-lightgreen");
+  border: solid green 5px;
+}
+.container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(310px, 1fr));
+}
+.header {
+  color: black;
+  font-size: 1.5rem;
+  padding: 0 0 1rem 0.5rem;
+}
+.card {
+  width: 300px;
+  height: 350px;
+}
+.image {
+  text-align: center;
+  height: 300px;
+  width: 300px;
+  position: relative;
+}
+img {
+  max-height: 100%;
+  max-width: 100%;
+  height: 300px;
+  width: 300px;
+}
+.validateButton {
+  position: fixed;
+  right: 50px;
+  bottom: 50px;
+}
+</style>


### PR DESCRIPTION
Instead of validatating -> waiting -> validatating -> ...

select all the images on which you see the logo and press the validation button.

For now, it only works with EU-bio label (easy to spot on an image). The idea is that most of the insight are fast to spot so we dedicate a gem to only validate. To invalidate an insight we need to be more careful, and so the classic game must be used

available at : https://deploy-preview-279--gifted-lalande-686eef.netlify.app/secretTool