### PR TITLE
feat: allow to change category without opening filters

### DIFF
--- a/src/components/QuestionFilter/index.vue
+++ b/src/components/QuestionFilter/index.vue
@@ -1,9 +1,20 @@
 <template>
   <div class="root">
     <div>
-      <div class="ui label blue large">
-        {{ $t("questions." + value.selectedInsightType) }}
-      </div>
+      <sui-dropdown
+        class="ui label blue large"
+        :text="$t('questions.' + value.selectedInsightType)"
+      >
+        <sui-dropdown-menu>
+          <sui-dropdown-item
+            v-for="insightType of availableInsightTypes"
+            :key="insightType"
+            @click="selectDirectlyInsightType(insightType)"
+            >{{ $t("questions." + insightType) }}</sui-dropdown-item
+          >
+        </sui-dropdown-menu>
+      </sui-dropdown>
+
       <div v-if="value.valueTag" class="ui label large">
         {{ $t("questions.filters.short_label.value") }}: {{ value.valueTag
         }}<i class="icon close" @click="removeFilter('valueTag')"></i>
@@ -142,6 +153,13 @@ export default {
     },
     selectInsightType: function(insightType) {
       this.formValues.selectedInsightType = insightType;
+    },
+    selectDirectlyInsightType: function(insightType) {
+      if (this.$props.value.selectedInsightType !== insightType) {
+        this.formValues.selectedInsightType = insightType;
+        this.formValues.valueTag = "";
+        this.validateForm();
+      }
     },
     clearFormField: function(key) {
       this.formValues[key] = "";

--- a/src/views/QuestionView.vue
+++ b/src/views/QuestionView.vue
@@ -300,10 +300,10 @@ export default {
       if (
         this.currentQuestion !== null &&
         this.currentQuestion !== NO_QUESTION_LEFT &&
-        this.selectedInsightType === "brand"
+        this.filters.selectedInsightType === "brand"
       ) {
         const urlParams = new URLSearchParams();
-        urlParams.append("type", this.selectedInsightType);
+        urlParams.append("type", this.filters.selectedInsightType);
         urlParams.append(
           "value_tag",
           reformatValueTag(this.currentQuestion.value)


### PR DESCRIPTION
The insight category has a menu, such that we can select the insight type faster.
Modifying the insight automatically reset the value since it is dependant on the insight type

![image](https://user-images.githubusercontent.com/45398769/135904032-4eae5ded-8c27-4627-8dea-e6aa185ef26e.png)
