### PR TITLE
feat: Added link to products in category/label/etc

### DIFF
--- a/src/i18n/common.json
+++ b/src/i18n/common.json
@@ -7,6 +7,7 @@
     "ingredients": "Ingredients",
     "product_weight": "product weight",
     "popularity_sort": "Sort by popularity",
+    "see_examples":"See examples of this ",
     "no": "No",
     "skip": "Skip",
     "yes": "Yes",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -7,6 +7,7 @@
     "ingredients": "Ingredients",
     "product_weight": "product weight",
     "popularity_sort": "Sort by popularity",
+    "see_examples":"See examples of this ",
     "no": "No",
     "skip": "Skip",
     "yes": "Yes",

--- a/src/views/QuestionView.vue
+++ b/src/views/QuestionView.vue
@@ -52,7 +52,7 @@
           <div v-if="valueTagQuestionsURL.length">
             <a :href="valueTagOFFURL" target="_blank">
               <div class="ui big label">
-                View {{ this.filters.selectedInsightType }} on Open Food Facts
+                View {{this.filters.selectedInsightType}} on Open Food Facts
                 <i
                   style="margin-left: 0.5rem"
                   class="external alternate icon small blue"

--- a/src/views/QuestionView.vue
+++ b/src/views/QuestionView.vue
@@ -17,6 +17,11 @@
                 ></i>
               </div>
             </router-link>
+            <a :href="valueTagOFFURL" target="_blank">
+              <div>
+                {{ $t("questions.see_examples") }} {{ this.filters.selectedInsightType }}
+              </div>
+            </a>
           </div>
           <div v-else>
             <div class="ui big label">{{ currentQuestion.value }}</div>
@@ -49,19 +54,6 @@
             }"
           />
           <div class="ui divider hidden"></div>
-          <div v-if="valueTagOFFURL">
-            <a :href="valueTagOFFURL" target="_blank">
-              <div class="ui big label">
-                View {{this.filters.selectedInsightType}} on Open Food Facts
-                <i
-                  style="margin-left: 0.5rem"
-                  class="external alternate icon small blue"
-                ></i>
-              </div>
-            </a>
-            <div class="ui divider hidden"></div>
-          </div>
-
           <div>
             <button
               data-inverted

--- a/src/views/QuestionView.vue
+++ b/src/views/QuestionView.vue
@@ -49,7 +49,7 @@
             }"
           />
           <div class="ui divider hidden"></div>
-          <div v-if="valueTagQuestionsURL.length">
+          <div v-if="valueTagOFFURL">
             <a :href="valueTagOFFURL" target="_blank">
               <div class="ui big label">
                 View {{this.filters.selectedInsightType}} on Open Food Facts

--- a/src/views/QuestionView.vue
+++ b/src/views/QuestionView.vue
@@ -49,6 +49,18 @@
             }"
           />
           <div class="ui divider hidden"></div>
+          <div v-if="valueTagQuestionsURL.length">
+            <a :href="valueTagOFFURL" target="_blank">
+              <div class="ui big label">
+                View {{ this.filters.selectedInsightType }} on Open Food Facts
+                <i
+                  style="margin-left: 0.5rem"
+                  class="external alternate icon small blue"
+                ></i>
+              </div>
+            </a>
+            <div class="ui divider hidden"></div>
+          </div>
 
           <div>
             <button
@@ -104,7 +116,7 @@
 <script>
 import { Cropper } from "vue-advanced-cropper";
 import robotoffService from "../robotoff";
-import { NO_QUESTION_LEFT } from "../const";
+import { NO_QUESTION_LEFT, OFF_URL } from "../const";
 import Product from "../components/Product";
 import LoadingSpinner from "../components/LoadingSpinner";
 import QuestionFilter from "../components/QuestionFilter/index";
@@ -311,6 +323,18 @@ export default {
           reformatValueTag(this.currentQuestion.value_tag)
         );
         return `/questions?${urlParams.toString()}`;
+      }
+      return "";
+    },
+    valueTagOFFURL: function() {
+      if (
+        this.currentQuestion !== null &&
+        this.currentQuestion !== NO_QUESTION_LEFT &&
+        this.currentQuestion.value_tag
+      ) {
+        return `${OFF_URL}/${
+          this.filters.selectedInsightType
+        }/${reformatValueTag(this.currentQuestion.value_tag)}`;
       }
       return "";
     },


### PR DESCRIPTION
### What
- Added a button that links to the category/label/brand page in the Open Food Facts website.
- The button is hidden in the product-weight filter

Closes #405 

### Screenshots
<img width="1552" alt="Screenshot 2022-03-25 at 10 35 05 PM" src="https://user-images.githubusercontent.com/63084088/160169503-e8e1be27-4f86-4483-b4fa-2c182ce584a7.png">
<img width="1552" alt="Screenshot 2022-03-25 at 10 35 17 PM" src="https://user-images.githubusercontent.com/63084088/160169545-71e6b391-8fd9-4616-9061-3de05ac5c94b.png">
<img width="1552" alt="Screenshot 2022-03-25 at 10 38 05 PM" src="https://user-images.githubusercontent.com/63084088/160169590-59ee8751-82c4-40ca-b2fd-ca4f22fe484f.png">
<img width="1552" alt="Screenshot 2022-03-25 at 10 35 31 PM" src="https://user-images.githubusercontent.com/63084088/160169568-5e866cd3-a265-4e8b-8554-4ebae91ae9ee.png">

### Fixes bug(s)
- #405 